### PR TITLE
userの検索結果からuser詳細に飛べるように修正

### DIFF
--- a/front/components/user/UserResultCard.tsx
+++ b/front/components/user/UserResultCard.tsx
@@ -1,0 +1,22 @@
+import { Avatar, Stack, HStack, Heading, Box } from '@chakra-ui/react'
+import Link from 'next/link'
+
+// TODO propsの型を変換する
+function UserResultCard(props: any) {
+  const { display_name, handle_name, icon } = props
+  return (
+    <>
+      <Link href={{ pathname: `/user/topPage/${handle_name}` }}>
+        <HStack>
+          <Avatar size="lg" src={icon} alt="icon" />{' '}
+          <Stack>
+            <Heading size="lg">{display_name}</Heading>
+            <Box>@{handle_name}</Box>
+          </Stack>
+        </HStack>
+      </Link>
+    </>
+  )
+}
+
+export default UserResultCard

--- a/front/pages/user/search.tsx
+++ b/front/pages/user/search.tsx
@@ -7,7 +7,7 @@ import { useAuthContext } from '../../auth/AuthContext'
 import { isLoggedIn } from '../../util'
 import UserHeader from '../../components/user/UserHeader'
 import ShopCard from '../../components/user/ShopCard'
-import Profile from '../../components/Profile'
+import UserResultCard from '../../components/user/UserResultCard'
 import {
   Box,
   Heading,
@@ -56,7 +56,7 @@ const Search: WithGetAccessControl<VFC> = (props) => {
             {usersInfo &&
               usersInfo.map((user: any, key: any) => {
                 return (
-                  <Profile
+                  <UserResultCard
                     key={key}
                     display_name={user.display_name}
                     handle_name={user.handle_name}


### PR DESCRIPTION
- 元々Profileコンポーネントを使用
- ProfileはShopでも使用されており、使い勝手が悪かったため、
   新しくUserResultCardコンポーネントを作成し、検索結果をクリックすると、
   Userの詳細画面（U-006）に飛べるように修正
　（下記の場合は、クリックすると山田太郎のページに飛ぶ）



![image](https://user-images.githubusercontent.com/61673527/151741762-297cfe1f-ed73-478c-bde8-e7cbe249b016.png)

FIX #188 