### PR TITLE
U-signup, S-signup周りの改修

### DIFF
--- a/front/components/InputForm.tsx
+++ b/front/components/InputForm.tsx
@@ -3,13 +3,19 @@ import {
   FormLabel,
   FormControl,
   Input,
-  Button,
 } from '@chakra-ui/react'
-import { useEffect, useState } from 'react'
-import { useForm, useFormContext } from 'react-hook-form'
+import { useEffect } from 'react'
+import { useFormContext } from 'react-hook-form'
 
 function InputForm(props: any) {
-  const { theme, text, defaultValue } = props
+  const { theme, text, defaultValue, type, validation, errorMessage } = props
+
+  let inputType = ''
+  if (type) {
+    inputType = type
+  } else {
+    inputType = 'text'
+  }
 
   const methods = useFormContext()
   const {
@@ -27,18 +33,17 @@ function InputForm(props: any) {
         <FormLabel fontSize="sm" htmlFor={theme}>
           {text}
         </FormLabel>
-        <Input
-          mb="25px"
-          bg="#FCFAF8"
-          borderColor="brand.color6"
-          id={theme}
-          {...methods.register(theme, {
-            // required: true,
-          })}
-        />
-        <FormErrorMessage>
-          {errors[theme] && 'This is required'}
-        </FormErrorMessage>
+        <>
+          <Input
+            mb="25px"
+            bg="#FCFAF8"
+            borderColor="brand.color6"
+            id={theme}
+            type={inputType}
+            {...methods.register(theme, validation)}
+          />
+          <FormErrorMessage>{errors[theme] && errorMessage}</FormErrorMessage>
+        </>
       </FormControl>
     </>
   )

--- a/front/pages/shop/signup.tsx
+++ b/front/pages/shop/signup.tsx
@@ -27,22 +27,29 @@ const Signup: WithGetAccessControl<VFC> = () => {
   const methods = useForm()
   const router = useRouter()
 
+  const postShopInfo = (authId: string, data: any) => {
+    const newShopInfo: newShopInfo = {
+      auth_id: authId,
+      handle_name: data.handle_name,
+      display_name: data.display_name,
+    }
+    axios
+      .post('/api/shops', newShopInfo)
+      .then(() => {
+        router.push('/shop/dashboard')
+      })
+      .catch((err: any) => {
+        console.error(err)
+      })
+  }
+
   const onSubmit = async (data: any) => {
     const auth = getAuth(firebase)
 
     createUserWithEmailAndPassword(auth, data.email, data.password)
       .then((userCredential) => {
         if (userCredential) {
-          const postShopInfo = () => {
-            const newShopInfo: newShopInfo = {
-              auth_id: userCredential.user.uid,
-              handle_name: data.handle_name,
-              display_name: data.display_name,
-            }
-            axios.post('/api/shops', newShopInfo)
-          }
-          postShopInfo()
-          router.push('/shop/dashboard')
+          postShopInfo(userCredential.user.uid, data)
         }
       })
       .catch((error: any) => {
@@ -85,10 +92,41 @@ const Signup: WithGetAccessControl<VFC> = () => {
           {message && <Message message={message} />}
           <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(onSubmit)}>
-              <InputForm theme="display_name" text="店舗名" />
-              <InputForm theme="handle_name" text="店舗のID名" />
-              <InputForm theme="email" text="メールアドレス" />
-              <InputForm theme="password" text="パスワード" />
+              <InputForm
+                theme="display_name"
+                text="店舗名"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="handle_name"
+                text="店舗のID名"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="email"
+                text="メールアドレス"
+                type="email"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="password"
+                text="パスワード"
+                type="password"
+                validation={{
+                  required: true,
+                  minLength: 6,
+                }}
+                errorMessage="6文字以上入力してください"
+              />
               <Center mt="10px">
                 <Button
                   backgroundColor="brand.color2"

--- a/front/pages/user/signup.tsx
+++ b/front/pages/user/signup.tsx
@@ -85,10 +85,41 @@ const Signup: WithGetAccessControl<VFC> = () => {
           </Center>
           <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(onSubmit)}>
-              <InputForm theme="display_name" text="ユーザーネーム" />
-              <InputForm theme="handle_name" text="ユーザーID" />
-              <InputForm theme="email" text="メールアドレス" />
-              <InputForm theme="password" text="パスワード" />
+              <InputForm
+                theme="display_name"
+                text="ユーザーネーム"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="handle_name"
+                text="ユーザーID"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="email"
+                text="メールアドレス"
+                type="email"
+                validation={{
+                  required: true,
+                }}
+                errorMessage="必須項目です"
+              />
+              <InputForm
+                theme="password"
+                text="パスワード"
+                type="password"
+                validation={{
+                  required: true,
+                  minLength: 6,
+                }}
+                errorMessage="6文字以上入力してください"
+              />
               <ImageUpload size="sm" theme="icon" text="アイコン画像" />
               <Center mt="10px">
                 <Button


### PR DESCRIPTION
- U-signup、S-signupで、パスワードは伏せ字にする
![image](https://user-images.githubusercontent.com/61673527/152131616-d1172947-bc12-4a5c-b3cc-00c301375ab7.png)


- S-signupの`postShopInfo`関数をonSubmitの外に切り出し

- バリデーション機能の雛形作成
   - `InputForm`コンポーネントにpropsを渡す際に、`validation`と`errorMessage`で渡すことでバリデーションをきかせることができる
   - `validation`はReact Hook Formで用意されている下記のいずれかから使用（詳しくはドキュメント参照）
      - required
      - min
      - max
      - minLength
      - maxLength
      - pattern
      - validate

   - `errorMessage`
      - エラーの際に表示するメッセージを渡す

 ```ts
// 例）サインアップ 画面の店舗名の場合
<InputForm
      theme="display_name"
      text="店舗名"
      validation={{
        required: true,
      }}
      errorMessage="必須項目です"
/>


// 例）サインアップ 画面のパスワードの場合
<InputForm
      theme="password"
      text="パスワード"
      type="password"
      validation={{
        required: true,
        minLength: 6,
      }}
      errorMessage="6文字以上入力してください"
/>

```

- エラーメッセージの表示
   - chakraの`FormErrorMessage`を使用
   - 見た目は別途きれいに整える必要あり

![image](https://user-images.githubusercontent.com/61673527/152131426-8ca241f9-3609-45af-b980-92227fcd7392.png)

FIX #245 
FIX #246 