### PR TITLE
Server: handle_nameチェック用のエンドポイント追加

### DIFF
--- a/server/__test__/shops/_get.ts
+++ b/server/__test__/shops/_get.ts
@@ -58,5 +58,16 @@ describe('Shop Get Request Tests', () => {
             expect(res.body.handle_name).to.equal('arasuna')
             expect(res.body.is_following).to.be.true
         })
+
+        it('GET /api/shops/handle/:handleName', async () => {
+            const res1 = await chai
+                .request(server)
+                .get('/api/shops/handle/arasuna')
+
+            const res2 = await chai.request(server).get('/api/users/handle/foo')
+
+            expect(res1.body).to.be.true
+            expect(res2.body).to.be.false
+        })
     })
 })

--- a/server/__test__/users/_get.ts
+++ b/server/__test__/users/_get.ts
@@ -48,6 +48,17 @@ describe('Users Get Request Tests', () => {
             expect(res.body).to.deep.equal(expectedData)
         })
 
+        it('GET /api/users/handle/:handleName', async () => {
+            const res1 = await chai
+                .request(server)
+                .get('/api/users/handle/kaori_hikita')
+
+            const res2 = await chai.request(server).get('/api/users/handle/foo')
+
+            expect(res1.body).to.be.true
+            expect(res2.body).to.be.false
+        })
+
         it('GET /api/users/:authId', async () => {
             const res = await chai
                 .request(server)

--- a/server/shop/controller.ts
+++ b/server/shop/controller.ts
@@ -32,6 +32,24 @@ export const getShop = async (req: Request, res: Response) => {
     }
 }
 
+export const getShopHandleNameCheck = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    try {
+        const handleName: String = req.params.handleName
+        const shop = await ShopsDataModel.findOne({ handle_name: handleName })
+
+        if (!shop) {
+            res.status(200).send(false)
+        } else {
+            res.status(400).send(true)
+        }
+    } catch (err) {
+        res.status(400).send(err)
+    }
+}
+
 export const getShopFromUser = async (req: Request, res: Response) => {
     try {
         const authId: string = req.params.authId

--- a/server/shop/route.ts
+++ b/server/shop/route.ts
@@ -1,10 +1,18 @@
 import { Router } from 'express'
-import { getShops, getShop, putShop, postShop, getShopFromUser } from './controller'
+import {
+    getShops,
+    getShop,
+    getShopHandleNameCheck,
+    putShop,
+    postShop,
+    getShopFromUser,
+} from './controller'
 
 const routes = Router()
 
 routes.get('/', getShops)
 routes.get('/details/:handleName', getShop)
+routes.get('/handle/:handleName', getShopHandleNameCheck)
 routes.get('/:authId', getShop)
 routes.get('/:authId/:handleName', getShopFromUser)
 

--- a/server/user/controller_get.ts
+++ b/server/user/controller_get.ts
@@ -68,6 +68,24 @@ export const search = async (req: Request, res: Response): Promise<void> => {
     }
 }
 
+export const getUserHandleNameCheck = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    try {
+        const handleName: String = req.params.handleName
+        const user = await userModel.findOne({ handle_name: handleName })
+
+        if (!user) {
+            res.status(200).send(false)
+        } else {
+            res.status(400).send(true)
+        }
+    } catch (err) {
+        res.status(400).send(err)
+    }
+}
+
 export const getOtherUser = async (
     req: Request,
     res: Response

--- a/server/user/route.ts
+++ b/server/user/route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import {
     getUsers,
     search,
+    getUserHandleNameCheck,
     getOtherUser,
     getUser,
     getFolloweeReviews,
@@ -22,6 +23,7 @@ const routes = Router()
 
 routes.get('/', getUsers)
 routes.get('/search', search)
+routes.get('/handle/:handleName', getUserHandleNameCheck)
 routes.get('/:authId', getUser)
 routes.get('/:authId/followee/reviews', getFolloweeReviews)
 routes.get('/:authId/followee/shops', getFolloweeShops)


### PR DESCRIPTION
サインアップ 時に使用するエンドポイント追加
- 存在する場合：true（作成できない）
- 存在しない場合：false（新しく作成することができる）

---
- `GET api/users/handle/:handleName`
- `GET api/shops/handle/:handleName`

---

- 存在する場合
   - res.status(400).send(true)

- 存在しない場合
   - res.status(200).send(false)


（補足）
テストも追加しました