### PR TITLE
front: ログイン・サインアップにALERTを追加

### DIFF
--- a/front/components/Alert.tsx
+++ b/front/components/Alert.tsx
@@ -12,7 +12,7 @@ import {
 import { useEffect, useRef } from 'react'
 
 function Alert(props: any) {
-  const { alert, message } = props
+  const { alert, setAlert, message } = props
 
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef(null)
@@ -21,7 +21,10 @@ function Alert(props: any) {
     if (alert) {
       onOpen()
     }
-  }, [])
+    if (!isOpen) {
+      setAlert(false)
+    }
+  }, [alert])
 
   return (
     <>

--- a/front/pages/shop/signin.tsx
+++ b/front/pages/shop/signin.tsx
@@ -9,6 +9,7 @@ import { isLoggedIn } from '../../util'
 import { useForm, FormProvider } from 'react-hook-form'
 import InputForm from '../../components/InputForm'
 import Header from '../../components/Header'
+import Alert from '../../components/Alert'
 
 import {
   Box,
@@ -22,7 +23,8 @@ import {
 import { FiCoffee } from 'react-icons/fi'
 
 const Signin: WithGetAccessControl<VFC> = () => {
-  const [message, setMessage] = useState<string>()
+  const [alert, setAlert] = useState<boolean>(false)
+  const [message, setMessage] = useState<string>('')
 
   const methods = useForm()
   const router = useRouter()
@@ -36,12 +38,19 @@ const Signin: WithGetAccessControl<VFC> = () => {
       })
       .catch((error: any) => {
         const errorCode = error.code
-        const errorMessage = error.message
-        console.log(errorCode, errorMessage)
-        if (errorCode === 'auth/email-already-in-use') {
-          setMessage('そのアドレスはすでに登録されています')
+        if (
+          String(errorCode) === 'auth/user-not-found' ||
+          String(errorCode) === 'auth/wrong-password'
+        ) {
+          setAlert(true)
+          setMessage(
+            'ご入力いただいたメールアドレスまたはパスワードは間違っています'
+          )
         }
-        console.log(errorCode, errorMessage)
+        if (String(errorCode) === 'auth/too-many-requests') {
+          setAlert(true)
+          setMessage('しばらくしてからログインしてください')
+        }
       })
   }
   return (
@@ -55,6 +64,8 @@ const Signin: WithGetAccessControl<VFC> = () => {
         <meta name="Sign-In" content="Shop サインイン" />
       </Head>
       <Header />
+      <Alert alert={alert} setAlert={setAlert} message={message} />
+
       <Box w={{ base: '80%', md: '65%' }} ml="auto" mr="auto">
         <Box
           my={12}

--- a/front/pages/user/signin.tsx
+++ b/front/pages/user/signin.tsx
@@ -31,7 +31,6 @@ const Signin: WithGetAccessControl<VFC> = () => {
       })
       .catch((error: any) => {
         const errorCode = error.code
-        console.log(errorCode)
         if (
           String(errorCode) === 'auth/user-not-found' ||
           String(errorCode) === 'auth/wrong-password'

--- a/front/pages/user/signin.tsx
+++ b/front/pages/user/signin.tsx
@@ -1,4 +1,4 @@
-import { VFC } from 'react'
+import { useState, VFC } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useForm, FormProvider } from 'react-hook-form'
@@ -10,11 +10,15 @@ import { isLoggedIn } from '../../util'
 
 import Header from '../../components/Header'
 import InputForm from '../../components/InputForm'
+import Alert from '../../components/Alert'
 
 import { Box, Button, Heading, Center, HStack, Link } from '@chakra-ui/react'
 import { FiCoffee } from 'react-icons/fi'
 
 const Signin: WithGetAccessControl<VFC> = () => {
+  const [alert, setAlert] = useState<boolean>(false)
+  const [message, setMessage] = useState<string>('')
+
   const methods = useForm()
   const router = useRouter()
 
@@ -27,9 +31,20 @@ const Signin: WithGetAccessControl<VFC> = () => {
       })
       .catch((error: any) => {
         const errorCode = error.code
-        const errorMessage = error.message
-        console.log(errorCode, errorMessage)
-        router.push('/index')
+        console.log(errorCode)
+        if (
+          String(errorCode) === 'auth/user-not-found' ||
+          String(errorCode) === 'auth/wrong-password'
+        ) {
+          setAlert(true)
+          setMessage(
+            'ご入力いただいたメールアドレスまたはパスワードは間違っています'
+          )
+        }
+        if (String(errorCode) === 'auth/too-many-requests') {
+          setAlert(true)
+          setMessage('しばらくしてからログインしてください')
+        }
       })
   }
   return (
@@ -43,6 +58,8 @@ const Signin: WithGetAccessControl<VFC> = () => {
         <meta name="Sign-In" content="ユーザーサインイン" />
       </Head>
       <Header />
+      <Alert alert={alert} setAlert={setAlert} message={message} />
+
       <Box w={{ base: '80%', md: '65%' }} ml="auto" mr="auto">
         <Box
           my={12}

--- a/front/pages/user/signup.tsx
+++ b/front/pages/user/signup.tsx
@@ -21,8 +21,6 @@ const Signup: WithGetAccessControl<VFC> = () => {
   const [alert, setAlert] = useState<boolean>(false)
   const [message, setMessage] = useState<string>('')
 
-  const alertRef = useRef(false)
-
   const methods = useForm()
   const router = useRouter()
 
@@ -32,7 +30,7 @@ const Signup: WithGetAccessControl<VFC> = () => {
     return res.data
   }
 
-  const userPost = (data: UserSignUpInfo, uid: string) => {
+  const postUserInfo = (data: UserSignUpInfo, uid: string) => {
     axios
       .post(
         '/api/users',
@@ -49,7 +47,7 @@ const Signup: WithGetAccessControl<VFC> = () => {
         }
       )
       .then(() => router.push('/user/timeline'))
-      .catch((res) => console.log(res))
+      .catch((err: any) => console.error(err))
   }
 
   const onSubmit = async (data: any) => {
@@ -63,13 +61,11 @@ const Signup: WithGetAccessControl<VFC> = () => {
         .then((userCredential) => {
           if (userCredential) {
             const user = userCredential.user
-            userPost(data, user.uid)
+            postUserInfo(data, user.uid)
           }
         })
         .catch((error: any) => {
           const errorCode = error.code
-          const errorMessage = error.message
-          console.log('🌸', errorCode)
           if (String(errorCode) === 'auth/email-already-in-use') {
             setAlert(true)
             setMessage('ご記入いただいたメールアドレスは既に使用されています')


### PR DESCRIPTION
FIX #261

![image](https://user-images.githubusercontent.com/86028587/152302679-395634eb-d515-4ee9-927f-2ef80bbf1e7d.png)

# アラートで表示するもの

signup
* ハンドルネームのかぶり
* メールアドレスのかぶり
* 
login
* メールアドレスとパスワードの間違い
* メールアドレスは合っているけど、パスワードを複数回間違える