### PR TITLE
Signup: IDとパスワードは半角英数記号のみ入力可能に修正

### DIFF
--- a/front/pages/shop/signup.tsx
+++ b/front/pages/shop/signup.tsx
@@ -118,9 +118,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   maxLength: 20,
-                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
+                  pattern: /^[a-zA-Z0-9_\-]*$/,
                 }}
-                errorMessage="必須項目です・20文字以内の半角英数記号で入力してください"
+                errorMessage="必須項目です・20文字以内の半角英数記号(_と-)で入力してください"
               />
               <InputForm
                 theme="email"
@@ -138,9 +138,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   minLength: 6,
-                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
+                  pattern: /^[a-zA-Z0-9_\-]*$/,
                 }}
-                errorMessage="必須項目です・6文字以上のの半角英数記号で入力してください"
+                errorMessage="必須項目です・6文字以上のの半角英数記号(_と-)で入力してください"
               />
               <Center mt="10px">
                 <Button

--- a/front/pages/shop/signup.tsx
+++ b/front/pages/shop/signup.tsx
@@ -118,8 +118,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   maxLength: 20,
+                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
                 }}
-                errorMessage="必須項目です・20文字以内で入力してください"
+                errorMessage="必須項目です・20文字以内の半角英数記号で入力してください"
               />
               <InputForm
                 theme="email"
@@ -137,8 +138,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   minLength: 6,
+                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
                 }}
-                errorMessage="必須項目です・6文字以上入力してください"
+                errorMessage="必須項目です・6文字以上のの半角英数記号で入力してください"
               />
               <Center mt="10px">
                 <Button

--- a/front/pages/user/signup.tsx
+++ b/front/pages/user/signup.tsx
@@ -119,9 +119,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   maxLength: 20,
-                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
+                  pattern: /^[a-zA-Z0-9_\-]*$/,
                 }}
-                errorMessage="必須項目です・20文字以内の半角英数記号で入力してください"
+                errorMessage="必須項目です・20文字以内の半角英数記号(_と-)で入力してください"
               />
               <InputForm
                 theme="email"
@@ -139,9 +139,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   minLength: 6,
-                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
+                  pattern: /^[a-zA-Z0-9_\-]*$/,
                 }}
-                errorMessage="必須項目です・6文字以上のの半角英数記号で入力してください"
+                errorMessage="必須項目です・6文字以上のの半角英数記号(_と-)で入力してください"
               />
               <ImageUpload size="sm" theme="icon" text="アイコン画像" />
               <Center mt="10px">

--- a/front/pages/user/signup.tsx
+++ b/front/pages/user/signup.tsx
@@ -119,8 +119,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   maxLength: 20,
+                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
                 }}
-                errorMessage="必須項目です・20文字以内で入力してください"
+                errorMessage="必須項目です・20文字以内の半角英数記号で入力してください"
               />
               <InputForm
                 theme="email"
@@ -138,8 +139,9 @@ const Signup: WithGetAccessControl<VFC> = () => {
                 validation={{
                   required: true,
                   minLength: 6,
+                  pattern: /^[a-zA-Z0-9!-/:-@¥[-`{-~]*$/,
                 }}
-                errorMessage="必須項目です・6文字以上入力してください"
+                errorMessage="必須項目です・6文字以上のの半角英数記号で入力してください"
               />
               <ImageUpload size="sm" theme="icon" text="アイコン画像" />
               <Center mt="10px">


### PR DESCRIPTION
* 半角英数記号以外を入力して「アカウント作成」ボタンをクリックした場合に、エラーが出るように修正

![image](https://user-images.githubusercontent.com/61673527/152328306-bd80d227-404a-4e56-9eb5-4a7b35545df7.png)

![image](https://user-images.githubusercontent.com/61673527/152328334-d0fbf4e5-ba9d-4ab7-a9a1-a4d1cc2d6316.png)

FIX #317



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201676789249169/1201763472887176) by [Unito](https://www.unito.io)
