### PR TITLE
Bugfix: 404ページの作成とshopCardの画像サイズ統一

### DIFF
--- a/front/components/user/ShopCard.tsx
+++ b/front/components/user/ShopCard.tsx
@@ -45,7 +45,13 @@ function ShopCard(props: any) {
           </Text>
         </Box>
         <Center>
-          <Image mb="20px" borderRadius="5px" src={icon} />
+          <Image
+            mb="20px"
+            boxSize="250px"
+            objectFit="cover"
+            borderRadius="5px"
+            src={icon}
+          />
         </Center>
         <Box mx="auto" borderRadius="5px" py="8px">
           <Text fontSize="13px" fontWeight="bold">

--- a/front/pages/404.tsx
+++ b/front/pages/404.tsx
@@ -1,0 +1,20 @@
+import { Center, Heading } from '@chakra-ui/react'
+import { VFC } from 'react'
+
+const Custom404: WithGetAccessControl<VFC> = () => {
+  return (
+    <>
+      <Center mb="50px">
+        <Heading size="md" mt="50px">
+          404 - Page Not Found
+        </Heading>
+      </Center>
+    </>
+  )
+}
+
+Custom404.getAccessControl = async () => {
+  return null
+}
+
+export default Custom404

--- a/front/pages/404.tsx
+++ b/front/pages/404.tsx
@@ -1,13 +1,25 @@
 import { Center, Heading } from '@chakra-ui/react'
+import { useRouter } from 'next/router'
 import { VFC } from 'react'
+import PrimaryButton from '../components/Button'
 
 const Custom404: WithGetAccessControl<VFC> = () => {
+  const router = useRouter()
+
   return (
     <>
       <Center mb="50px">
         <Heading size="md" mt="50px">
           404 - Page Not Found
         </Heading>
+      </Center>
+      <Center>
+        <PrimaryButton
+          text="topページに戻る"
+          onclick={() => {
+            router.push('/index')
+          }}
+        />
       </Center>
     </>
   )


### PR DESCRIPTION
FIX #341  
FIX #343 

【404ページ見本】
![image](https://user-images.githubusercontent.com/86028587/152475890-908438fb-2a15-4804-852c-ae4c56ce5d72.png)

折衷案で、/indexに戻るボタンを作成しました。
