### PR TITLE
Fix: ショップ一覧とお気に入りショップ一覧でカードが並んだ時、センターからずれていたのを修正

### DIFF
--- a/front/components/user/ShopCard.tsx
+++ b/front/components/user/ShopCard.tsx
@@ -11,7 +11,8 @@ function ShopCard(props: any) {
       <Box
         w="80%"
         h="auto"
-        m="40px"
+        mt="40px"
+        mx="auto"
         backgroundColor="#fcf7f0"
         border="0.2px"
         borderRadius="24px"


### PR DESCRIPTION
@naonmr 
ご確認お願いします！
（イシューは特に入れていなかったです。）

<img width="353" alt="スクリーンショット 2022-02-04 16 44 14" src="https://user-images.githubusercontent.com/86092696/152490990-45eb4abe-ba0d-495d-8d93-1ca952989d7f.png">

<img width="350" alt="スクリーンショット 2022-02-04 16 44 37" src="https://user-images.githubusercontent.com/86092696/152491008-1ac1444b-f029-43ba-83e5-a64f8044e853.png">

