### PR TITLE
U-004 / U-005: お気に入りショップ数が一致しないバグ修正

### DIFF
--- a/server/user/controller_get.ts
+++ b/server/user/controller_get.ts
@@ -137,13 +137,30 @@ export const getOtherUser = async (
 
 export const getUser = async (req: Request, res: Response): Promise<void> => {
     try {
-        const data = await userModel.findOne(
+        const user = await userModel.findOne(
             { auth_id: req.params.authId },
             { _id: 0, __v: 0 }
         )
 
-        if (data) {
-            res.json(data)
+        if (user) {
+            for (const shopName of user.followee_shops_handle_names) {
+                const shop = await ShopsDataModel.findOne({
+                    handle_name: shopName,
+                })
+
+                if (shop) {
+                    if (!shop.publish_state) {
+                        user.followee_shops_handle_names.splice(
+                            user.followee_shops_handle_names.indexOf(
+                                shop.handle_name
+                            ),
+                            1
+                        )
+                    }
+                }
+            }
+
+            res.json(user)
         } else {
             res.status(400).json({ error: 'userが見つかりません' })
         }


### PR DESCRIPTION
- ひとまず、サーバー側で、非公開中のショップは、followee_shops_handle_namesの中から外してフロント側に返すという対応で修正
- データベースのデータ自体は変更していないため、フォローしているショップが再度公開された場合は、元のデータのまま返る


- 挙動例（カッコ内は修正前の数字）
   1. Kaoriが、coffeeeeen,  moon_bucks,  arasuna,  inutahiko_coffeeをフォロー
      - Kaoriのマイページに表示される、お気に入りショップ数   => 4（4）
      - お気に入りショップページに表示されるショップカード数 => 4（4）
      
   2. coffeeeeenが、非公開になる
      - Kaoriのマイページに表示される、お気に入りショップ数   => 3（4）
      - お気に入りショップページに表示されるショップカード数 => 3（3）
    
   3.  coffeeeeenが、公開中になる
      - Kaoriのマイページに表示される、お気に入りショップ数   => 4（4）
      - お気に入りショップページに表示されるショップカード数 => 4（4）
 

FIX #340 