### PR TITLE
fix: ディスプレイネームをセンターよせに

### DIFF
--- a/front/components/Profile.tsx
+++ b/front/components/Profile.tsx
@@ -7,7 +7,7 @@ function PhotoImage(props: any) {
     <Box w='65%' my='0' ml='auto' mr='auto'>
       <VStack>
         <Avatar size="2xl" mt='8' mb='2' src={icon} alt="icon" />{' '}
-        <Heading size="lg">{display_name}</Heading>
+        <Heading size="lg" textAlign="center">{display_name}</Heading>
         <Text fontSize='20px' letterSpacing='1px' pb='8'>@{handle_name}</Text>
       </VStack>
     </Box>


### PR DESCRIPTION
@mahomiyata 

![スクリーンショット 2022-02-07 12 07 33](https://user-images.githubusercontent.com/86092696/152718407-404eb6c0-7fdb-4ec7-a6a5-e687741dca84.png)
